### PR TITLE
Upgrade play, scalatest and reactive mongo versions

### DIFF
--- a/modules/play-test-utils/src/main/scala/jce/test/play/MockSugar.scala
+++ b/modules/play-test-utils/src/main/scala/jce/test/play/MockSugar.scala
@@ -5,7 +5,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.stubbing.Stubber
 import org.mockito.verification.VerificationMode
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 trait MockSugar extends MockitoSugar {
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -15,7 +15,7 @@ object Common {
     version := appVersion,
     organization := "jce.tools",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "2.2.4",
+      "org.scalatest" %% "scalatest" % "3.0.1",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
     ),
     resolvers ++= Seq(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,5 +1,5 @@
 object Versions {
   val appVersion = "0.5.0"
-  val playVersion = "2.5.9"
-  val reactiveMongoVersion = "0.12.0"
+  val playVersion = "2.5.10"
+  val reactiveMongoVersion = "0.12.1"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.10")


### PR DESCRIPTION
Ran in a `ClassNotFoundException` on `MockitoSugar` when using this in a project with ScalaTest 3.